### PR TITLE
feat(gcg): optionally support using hMetis

### DIFF
--- a/packages/gcg.nix
+++ b/packages/gcg.nix
@@ -20,7 +20,7 @@
 
   hmetis = pkgs.stdenvNoCC.mkDerivation (
     finalAttrs: {
-      pname = "hmetis";
+      inherit (pkgs.hmetis) pname meta;
       version = "2.0pre1";
 
       src = pkgs.fetchurl {
@@ -37,17 +37,6 @@
         mkdir -p $out/bin
         install -Dm755 ${paths.${pkgs.system}}/hmetis${finalAttrs.version} $out/bin/hmetis
       '';
-
-      meta = with lib; {
-        description = "hMETIS is a set of programs for partitioning hypergraphs";
-        homepage = "http://glaros.dtc.umn.edu/gkhome/metis/hmetis/overview";
-        sourceProvenance = with sourceTypes; [binaryNativeCode];
-        license = licenses.unfree;
-        platforms = [
-          "i686-linux"
-          "x86_64-linux"
-        ];
-      };
     }
   );
 in

--- a/packages/gcg.nix
+++ b/packages/gcg.nix
@@ -18,8 +18,8 @@
     })
     .gcg;
 
-  hmetis = (
-    pkgs.stdenvNoCC.mkDerivation (finalAttrs: {
+  hmetis = pkgs.stdenvNoCC.mkDerivation (
+    finalAttrs: {
       pname = "hmetis";
       version = "2.0pre1";
 
@@ -48,7 +48,7 @@
           "x86_64-linux"
         ];
       };
-    })
+    }
   );
 in
   pkgs.stdenv.mkDerivation {

--- a/packages/gcg.nix
+++ b/packages/gcg.nix
@@ -89,6 +89,11 @@ in
       for file in ${builtins.concatStringsSep " " debugFiles}; do
         sed -i '1s/^/#define SCIP_DEBUG\n/' $file
       done
+
+      # Fix zsh calls
+      substituteInPlace \
+        src/gcg/dec_hcgpartition.cpp src/gcg/dec_hrgpartition.cpp src/gcg/dec_hrcgpartition.cpp \
+        --replace-fail "zsh -c" "${pkgs.zsh}/bin/zsh -c"
     '';
 
     enableParallelBuilding = true;


### PR DESCRIPTION
Support using hMetis for hypergraph partitioning in three of GCG's detectors.

See https://gcg.or.rwth-aachen.de/doc-3.5.0/install-manually.html

Closes #1 